### PR TITLE
Removing the recursive check

### DIFF
--- a/widgets/SeoHead.php
+++ b/widgets/SeoHead.php
@@ -105,11 +105,8 @@ class SeoHead extends CWidget
      */
     protected function renderCanonical()
     {
-        $request = Yii::app()->getRequest();
-        $url = $request->getUrl();
-
-        // Make sure that we do not create a recursive canonical redirect.
-        if ($this->_canonical !== $url && $this->_canonical !== $request->getHostInfo().$url)
+        // Make sure the Canonical link is populated before writing it to the page.
+        if ($this->_canonical)
             echo '<link rel="canonical" href="'.$this->_canonical.'" />';
     }
 }

--- a/widgets/SeoHead.php
+++ b/widgets/SeoHead.php
@@ -97,16 +97,6 @@ class SeoHead extends CWidget
             echo '<meta property="'.$name.'" content="'.$content.'" />'; // we can't use Yii's method for this.
 
         if ($this->_canonical !== null)
-            $this->renderCanonical();
-    }
-
-    /**
-     * Renders the canonical link tag.
-     */
-    protected function renderCanonical()
-    {
-        // Make sure the Canonical link is populated before writing it to the page.
-        if ($this->_canonical)
             echo '<link rel="canonical" href="'.$this->_canonical.'" />';
     }
 }


### PR DESCRIPTION
There is no harm in having a canonical tag that says the current page
is the authoritative url.  By always rendering it, it is easier to test
for any problems, and there are some SEO experts that say  there is
benefit in always having it.
